### PR TITLE
catch an exception in metsis_ts_bokeh.utils.inc due to new plotting API

### DIFF
--- a/includes/metsis_ts_bokeh.utils.inc
+++ b/includes/metsis_ts_bokeh.utils.inc
@@ -95,6 +95,15 @@ function adc_get_ts_bokeh_plot_y_vars() {
 
   $ts_bokeh_plot_vars = adc_get_ts_bokeh_plot_vars($data_uri);
   $y_vars = $ts_bokeh_plot_vars['y_axis'];
+  
+  /* the if statment below temporary handles the new plotting API 
+  * to support the plotting of vertical profiles
+  * in such case the get 'adc_get_ts_bokeh_plot_vars' will return 'x_axis' instead of 'y_axis'
+  * based on the NetCDF dimension 
+  */
+  if(empty($y_vars))
+      $y_vars = $ts_bokeh_plot_vars['x_axis'];
+  
   ksort($y_vars);
   $hy_vars = [];
   foreach ($y_vars as $yv) {

--- a/includes/metsis_ts_bokeh.utils.inc
+++ b/includes/metsis_ts_bokeh.utils.inc
@@ -110,5 +110,5 @@ function adc_get_ts_bokeh_plot_y_vars() {
     $hy_vars[$yv] = $yv;
   }
   return ($hy_vars);
-
+  unset($y_vars);
 }


### PR DESCRIPTION
I added an hackish ' if statment '  which temporary handles the new plotting API  to support the plotting of vertical profiles.
In such case the get `adc_get_ts_bokeh_plot_vars` will return `x_axis` instead of `y_axis` based on the NetCDF dimensions.